### PR TITLE
タイムゾーンが UTC なので、最新話更新日が +9 時間ずれてしまう

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV KINDLEGEN_FILE kindlegen_linux_2.6_i386_v2_9.tar.gz
 WORKDIR /temp
 
 RUN set -x \
+ # install tzdata
+ && apk --no-cache add tzdata \
  # install AozoraEpub3
  && wget https://github.com/kyukyunyorituryo/AozoraEpub3/releases/download/${AOZORAEPUB3_VERSION}/${AOZORAEPUB3_FILE}.zip \
  && unzip -q ${AOZORAEPUB3_FILE} \

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ version: "3.7"
 services:
   app:
     image: whiteleaf/narou
+    environment:
+      TZ: Asia/Tokyo
     command: ["narou", "web", "-np", "33000"]
     volumes:
       - .:/novel:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.7"
 services:
   app:
     build: .
+    environment:
+      TZ: Asia/Tokyo
     image: narou
     command: ["narou", "web", "-np", "33000"]
     volumes:


### PR DESCRIPTION
小説家になろうの目次にある投稿日がタイムゾーンを持っていないため、そのまま更新してしまうと 9 時間進んでしまうようでした。

PC のタイムゾーンを変更して、ブラウザで目次を見に行きましたが時間はそのままだったので、たぶん `Asia/Tokyo` に固定して大丈夫かと思います。